### PR TITLE
chore: upgrade IOS SDK to 1.1.4

### DIFF
--- a/ios/persona_flutter.podspec
+++ b/ios/persona_flutter.podspec
@@ -16,7 +16,7 @@ Integrate the Persona Inquiry flow directly into your app with native SDK.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'PersonaInquirySDK', '1.1.3'
+  s.dependency 'PersonaInquirySDK', '1.1.4'
   s.static_framework = true
   s.platform = :ios, '11.0'
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.


### PR DESCRIPTION
Upgrading IOS SDK to 1.1.4 to fix a defect with sandbox immediately failing an inquiry rather than going to the next verification type.  See https://docs.withpersona.com/docs/mobile-sdk-changelogs#v114---2021-04-09