### PR TITLE
fix: birthday fromJson serialization

### DIFF
--- a/lib/src/types/attributes.dart
+++ b/lib/src/types/attributes.dart
@@ -19,7 +19,9 @@ class InquiryAttributes {
     return InquiryAttributes(
       name: InquiryName.fromJson(json["name"]),
       address: InquiryAddress.fromJson(json["address"]),
-      birthdate: DateTime.parse(json["birthdate"] as String),
+      birthdate: json['birthdate'] == null
+          ? null
+          : DateTime.parse(json['birthdate'] as String),
     );
   }
 }

--- a/lib/src/types/fields.dart
+++ b/lib/src/types/fields.dart
@@ -35,7 +35,9 @@ class InquiryFields {
     return InquiryFields(
       name: InquiryName.fromJson(json["name"]),
       address: InquiryAddress.fromJson(json["address"]),
-      birthdate: DateTime.parse(json["birthdate"] as String),
+      birthdate: json['birthdate'] == null
+          ? null
+          : DateTime.parse(json['birthdate'] as String),
       phoneNumber: json["phoneNumber"] as String?,
       emailAddress: json["emailAddress"] as String?,
       additionalFields: json["additionalFields"] as Map<String, dynamic>,


### PR DESCRIPTION
When using `InquiryAttributes` or `InquiryFields` and the birthdate is null, the fromJson breaks. This PR is to handle when the birthday is null.