### PR TITLE
fix: export contents of types/typedefs.dart

### DIFF
--- a/lib/persona_flutter.dart
+++ b/lib/persona_flutter.dart
@@ -6,3 +6,4 @@ export 'src/types/relationships.dart';
 export 'src/types/fields.dart';
 export 'src/types/theme.dart';
 export 'src/types/configurations.dart';
+export 'src/types/typedefs.dart';


### PR DESCRIPTION
This PR exports the types/typedefs.dart file from persona_flutter.dart