### PR TITLE
Update Persona SDK to vr2.10.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.withpersona.sdk2:inquiry:2.10.9"
+    implementation "com.withpersona.sdk2:inquiry:2.10.10"
 }


### PR DESCRIPTION
Update the Persona SDK version to vr2.10.10 as vr 2.10.9 are causing crashed issue on Android Device.