### PR TITLE
fix: add stub Persona.Inquiry.Theme to fix missing R.style issues

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Persona.Inquiry.Theme" parent="@style/Base.Persona.Inquiry.Theme"></style>
+</resources>


### PR DESCRIPTION
Was getting same issue as https://github.com/jorgefspereira/persona_flutter/issues/50 when compiling my app with Flutter 3.24.3.

I was able to fix it by adding an empty `styles` and verified that the custom styles were merged correctly in the app:

![Screenshot 2024-09-26 at 16 35 05](https://github.com/user-attachments/assets/39460f04-ee45-49e2-b1aa-9051ac16ce44)
