### PR TITLE
bump persona android to v2.20.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,5 +59,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.withpersona.sdk2:inquiry:2.12.10"
+    implementation "com.withpersona.sdk2:inquiry:2.20.0"
 }


### PR DESCRIPTION
Thanks so much for building & maintaining this lib! We're using `persona_flutter` in our mobile app and are running into some bugs on android that were fixed in releases after `2.12.10`. 

This PR bumps the android sdk version to `2.20.0`. let me know if there's anything else that needs to be done in order for this PR to be feasible to merge