### PR TITLE
fix: `PlatformException (PlatformException(not_initialized, Inquiry not initialized, null, null))`

### DIFF
--- a/android/src/main/kotlin/com/jorgefspereira/persona_flutter/PersonaFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/jorgefspereira/persona_flutter/PersonaFlutterPlugin.kt
@@ -211,23 +211,33 @@ class PersonaFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Stre
 
                     inquiry = builder?.build()
                 }
+
+                result.success(null)
             }
             "start" -> {
-                val activity = this.activity ?: return
-                val inquiry = this.inquiry ?: return
+                val inquiry = this.inquiry
+                if (inquiry == null) {
+                    result.error("not_initialized", "Inquiry not initialized", null)
+                    return
+                }
+                val activity = this.activity
+                if (activity == null) {
+                    result.error("no_activity", "Could not find activity", null)
+                    return
+                }
 
                 isResultSubmitted = false
-                
+
                 if (disablePresentationAnimation) {
-                     activity.overridePendingTransition(0, 0)
+                    activity.overridePendingTransition(0, 0)
                 }
 
                 inquiry.start(activity, requestCode)
-                
-                 if (disablePresentationAnimation) {
-                     activity.overridePendingTransition(0, 0)
+
+                if (disablePresentationAnimation) {
+                    activity.overridePendingTransition(0, 0)
                 }
-                
+
                 result.success("Inquiry started")
             }
             "dispose" -> {

--- a/ios/Classes/SwiftPersonaFlutterPlugin.swift
+++ b/ios/Classes/SwiftPersonaFlutterPlugin.swift
@@ -120,7 +120,7 @@ public class SwiftPersonaFlutterPlugin: NSObject, FlutterPlugin, InquiryDelegate
             if var inquiryBuilder = inquiryBuilder { // Use var to allow modification
                 if let sessionToken = sessionToken { inquiryBuilder = inquiryBuilder.sessionToken(sessionToken) }
                 if let theme = theme { inquiryBuilder = inquiryBuilder.theme(theme) }
-                if let locale = locale { inquiryBuilder.locale(locale) }
+                if let locale = locale { inquiryBuilder = inquiryBuilder.locale(locale) }
                 if let styleVariant = styleVariant { inquiryBuilder = inquiryBuilder.styleVariant(styleVariant) }
                 
                 if returnCollectedData {
@@ -138,11 +138,16 @@ public class SwiftPersonaFlutterPlugin: NSObject, FlutterPlugin, InquiryDelegate
             result(nil)
             
         case "start":
-            if let inquiry = _inquiry, let controller = UIApplication.shared.delegate?.window??.rootViewController {
-                inquiry.start(from: controller, animated: !_disablePresentationAnimation)
-            } else {
+            guard let inquiry = _inquiry else {
                 result(FlutterError(code: "not_initialized", message: "Inquiry not initialized", details: nil))
+                return
             }
+            guard let controller = Self.rootViewController else {
+                result(FlutterError(code: "no_view_controller", message: "Could not find root view controller", details: nil))
+                return
+            }
+            inquiry.start(from: controller, animated: !_disablePresentationAnimation)
+            result(nil)
             
         case "dispose":
             if let inquiry = _inquiry {
@@ -591,7 +596,21 @@ public class SwiftPersonaFlutterPlugin: NSObject, FlutterPlugin, InquiryDelegate
     }
     
     // MARK: Helpers
-    
+
+    private static var rootViewController: UIViewController? {
+        if let controller = UIApplication.shared.delegate?.window??.rootViewController {
+            return controller
+        }
+        if #available(iOS 13.0, *) {
+            return UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }?
+                .rootViewController
+        }
+        return nil
+    }
+
     func dateFormatter() -> DateFormatter {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd hh:mm:ss"


### PR DESCRIPTION
Hi @jorgefspereira, thanks again for maintaining this library. i recently version bumped `persona_flutter` to latest (`4.0.0`) and ran into the following issue:

```
PlatformException (PlatformException(not_initialized, Inquiry not initialized, null, null))
```

This was happening despite calling `PersonaInquiry.init()`. Decided to try and diagnose the issue and encountered a few bug which i've fixed:

## Fix inquiry start failure on scene-based iOS apps

### Root view controller resolution (primary fix)

The `start` method used a compound `if let` that required both the inquiry object and the root view controller to be non-nil, with a single error path:

```swift
if let inquiry = _inquiry, let controller = UIApplication.shared.delegate?.window??.rootViewController {
```

On iOS 13+, apps using the `UIScene` lifecycle manage windows through `UIWindowScene` rather than `UIApplicationDelegate`. In that case, `UIApplication.shared.delegate?.window` returns `nil`, causing `start` to fail with a `not_initialized` error even when the inquiry was correctly built.

The fix separates the two guards with distinct error codes so the actual failure point is clear, and adds a fallback that resolves the root view controller through `connectedScenes` when the traditional app delegate window path returns nil. This covers both legacy and scene-based app architectures.

### Missing result callback on success

The `start` handler only called the Flutter `result` callback in the error branch. On success, the callback was never invoked, meaning the Dart `Future<void>` returned by `invokeMethod('start')` would never complete. Any caller `await`ing `start()` would hang indefinitely. The fix calls `result(nil)` after successfully starting the inquiry.

### Discarded builder return value for locale

In the `inquiryId` flow, the `locale` builder call was missing its reassignment:

```swift
// Before — return value discarded, locale silently dropped
inquiryBuilder.locale(locale)

// After — consistent with every other builder call in the same block
inquiryBuilder = inquiryBuilder.locale(locale)
```

The Persona SDK builder methods return a new or updated builder instance. Without capturing the return value, the locale configuration was silently lost for inquiry-ID-based flows.